### PR TITLE
updating papermill to be on main branch (new github lingo) vs release

### DIFF
--- a/docker_build.yaml
+++ b/docker_build.yaml
@@ -8,6 +8,6 @@ app: airflow
 args:
   AIRFLOW_VERSION: 1.10.10
   AIRFLOW_DEPS: kubernetes,slack,aws,s3,elasticsearch,postgres
-  PAPERMILL_PACKAGE: "git+https://github.com/viaduct-ai/papermill.git@2ed27f6fa59ab0622aa581dbcecaf8dae40c335c#egg=papermill[s3]"
+  PAPERMILL_PACKAGE: "git+https://github.com/viaduct-ai/papermill.git@674d31dcbec73622f292f44224b819746cbfa0b5#egg=papermill[s3]"
 # Environment variables to inject as build arguments
 env: {}


### PR DESCRIPTION
to take advantage of inspect_notebook for required params